### PR TITLE
feat: add auto waypoint support for TomTom

### DIFF
--- a/Modules/Options/TrackerTab/QuestieOptionsTracker.lua
+++ b/Modules/Options/TrackerTab/QuestieOptionsTracker.lua
@@ -14,6 +14,9 @@ local TrackerLinePool = QuestieLoader:ImportModule("TrackerLinePool")
 ---@type TrackerQuestTimers
 local TrackerQuestTimers = QuestieLoader:ImportModule("TrackerQuestTimers")
 
+---@type TrackerUtils
+local TrackerUtils = QuestieLoader:ImportModule("TrackerUtils")
+
 ---@type l10n
 local l10n = QuestieLoader:ImportModule("l10n")
 
@@ -577,6 +580,22 @@ function QuestieOptions.tabs.tracker:Initialize()
                             QuestieTracker:ResetLocation()
                             QuestieTracker:Update()
                         end
+                    },
+                    tomtomAutoTargetMode = {
+                            type = "toggle",
+                            order = 11.5,
+                            name = function() return l10n('Auto Waypoint') end,
+                            desc = function() return l10n('Enable if TomTom will automatically point to the closest quest.') end,
+                            disabled = function() return not Questie.db.profile.trackerEnabled end,
+                            hidden = function() return not IsAddOnLoaded("TomTom") end,
+                            get = function() return Questie.db.profile.tomtomAutoTargetMode end,
+                            set = function(_, value)
+                                Questie.db.profile.tomtomAutoTargetMode = value
+                                TrackerUtils:StartTomTomAutoTracking()
+                                if not value then
+                                    TrackerUtils:StopTomTomAutoTracking()
+                                end
+                            end
                     },
                     Spacer_Sliders = QuestieOptionsUtils:Spacer(12),
                     trackerHeightRatio = {

--- a/Modules/Tracker/QuestieTracker.lua
+++ b/Modules/Tracker/QuestieTracker.lua
@@ -174,6 +174,17 @@ function QuestieTracker.Initialize()
     end
     -- Questie:Print("[QuestieTracker] Quest frame initialized") -- Removed to reduce login spam
 
+    if Questie.db.profile.tomtomAutoTargetMode then
+        success, err = pcall(function()
+            TrackerUtils:StartTomTomAutoTracking()
+        end)
+        if not success then
+            Questie:Print("|cFFFF0000[QuestieTracker] ERROR: Failed to start TomTom auto tracking: " .. tostring(err) .. "|r")
+            return
+        end
+        Questie:Print("[QuestieTracker] TomTom auto tracking started")
+    end
+
     -- Initialize tracker functions
     TrackerLinePool.Initialize(trackerQuestFrame)
     TrackerFadeTicker.Initialize(trackerBaseFrame, trackerHeaderFrame)
@@ -192,6 +203,7 @@ function QuestieTracker.Initialize()
 
     -- Insures all other data we're getting from other addons and WoW is loaded. There are edge
     -- cases where Questie loads too fast before everything else is available.
+
     C_Timer.After(1.0, function()
         -- Hide frames during startup
         if QuestieTracker.alreadyHooked then


### PR DESCRIPTION

## Feature 
- Adds a option in the tracker to be able to use TomTom to auto set the closest spawn or objective as the waypoint


### Misc
 - Add `QuestieCompat.C_Timer` compat in QuestieDataCollector.lua fixing a nill error