### PR TITLE
fix: modularize TomTomAuto feature

### DIFF
--- a/Modules/TomTom/TomTomAuto.lua
+++ b/Modules/TomTom/TomTomAuto.lua
@@ -1,0 +1,94 @@
+---@class TomTomAuto
+local TomTomAuto = QuestieLoader:CreateModule("TomTomAuto")
+
+-------------------------
+-- Import Questie modules.
+-------------------------
+---@type QuestiePlayer
+local QuestiePlayer = QuestieLoader:ImportModule("QuestiePlayer")
+---@type QuestieMap
+local QuestieMap = QuestieLoader:ImportModule("QuestieMap")
+---@type TrackerUtils
+local TrackerUtils = QuestieLoader:ImportModule("TrackerUtils")
+---@type ThreadLib
+local ThreadLib = QuestieLoader:ImportModule("ThreadLib")
+
+--- COMPATIBILITY ---
+local C_Timer = QuestieCompat.C_Timer
+
+
+local tomtomAutoTrackTimer
+local lastWaypoint
+
+--- Finds the closest incomplete quest in the player's quest log for TomTom auto-targeting.
+--- @return table|nil The closest quest table, or nil if none found or TomTom is not enabled.
+function TomTomAuto:GetTomTomAutoTargetQuest()
+    if not TomTom or not Questie.db.profile.tomtomAutoTargetMode then return nil end
+
+    local closestQuest = nil
+    local closestDistance = math.huge
+
+    -- Iterate all quests in the player's quest log
+    for questId, quest in pairs(QuestiePlayer.currentQuestlog or {}) do
+        if quest and type(quest) == "table" then
+            -- Skip completed quests
+            local isComplete = 0
+            if quest.IsComplete and type(quest.IsComplete) == "function" then
+                isComplete = quest:IsComplete()
+            elseif quest.isComplete ~= nil then
+                isComplete = quest.isComplete and 1 or 0
+            end
+
+            if isComplete ~= 1 and questId then
+                -- Calculate distance to this quest's objectives
+                local distance = TrackerUtils:GetDistanceToClosestObjective(questId)
+                if distance and distance < closestDistance then
+                    closestDistance = distance
+                    closestQuest = quest
+                end
+            end
+        end
+    end
+
+    return closestQuest
+end
+
+-- Gets the closest quest and set the TomTom target
+function TomTomAuto:updateQuestWaypoint()
+    local quest = TomTomAuto:GetTomTomAutoTargetQuest()
+    if quest then
+        local questId = quest.Id or tostring(quest)
+        local spawn, zone, name = QuestieMap:GetNearestQuestSpawn(quest)
+        if (not spawn) and quest.objective ~= nil then
+            spawn, zone, name = QuestieMap:GetNearestSpawn(quest.objective)
+        end
+        if spawn then
+            TrackerUtils:SetTomTomTarget(name, zone, spawn[1], spawn[2])
+        end
+    end
+end
+
+
+--- Starts automatic TomTom waypoint tracking to the closest incomplete quest.
+--- Sets a timer to update the waypoint every 5 seconds.
+function TomTomAuto:StartTomTomAutoTracking()
+    if not TomTom or not TomTom.AddWaypoint or not Questie.db.profile.tomtomAutoTargetMode then return end
+
+    if tomtomAutoTrackTimer then
+        tomtomAutoTrackTimer:Cancel()
+        tomtomAutoTrackTimer = nil
+    end
+
+    tomtomAutoTrackTimer = C_Timer.NewTicker(5.0, function()
+        TomTomAuto:updateQuestWaypoint()
+    end)
+end
+
+--- Stops the TomTom auto-tracking timer and clears the last waypoint reference.
+function TomTomAuto:StopTomTomAutoTracking()
+    if tomtomAutoTrackTimer then
+        tomtomAutoTrackTimer:Cancel()
+        tomtomAutoTrackTimer = nil
+    end
+    lastWaypoint = nil
+end

--- a/Modules/Tracker/QuestieTracker.lua
+++ b/Modules/Tracker/QuestieTracker.lua
@@ -41,6 +41,8 @@ local QuestieDB = QuestieLoader:ImportModule("QuestieDB")
 local l10n = QuestieLoader:ImportModule("l10n")
 ---@type QuestieDebugOffer
 local QuestieDebugOffer = QuestieLoader:ImportModule("QuestieDebugOffer")
+---@type TomTomAuto
+local TomTomAuto = QuestieLoader:ImportModule("TomTomAuto")
 
 --- COMPATIBILITY ---
 local C_Timer = QuestieCompat.C_Timer
@@ -174,15 +176,15 @@ function QuestieTracker.Initialize()
     end
     -- Questie:Print("[QuestieTracker] Quest frame initialized") -- Removed to reduce login spam
 
-    if Questie.db.profile.tomtomAutoTargetMode then
+    if TomTom and Questie.db.profile.tomtomAutoTargetMode then
         success, err = pcall(function()
-            TrackerUtils:StartTomTomAutoTracking()
+            TomTomAuto:StartTomTomAutoTracking()
         end)
         if not success then
-            Questie:Print("|cFFFF0000[QuestieTracker] ERROR: Failed to start TomTom auto tracking: " .. tostring(err) .. "|r")
+            Questie:Print("|cFFFF0000[TomTom] ERROR: Failed to start TomTom Auto tracking: " .. tostring(err) .. "|r")
             return
         end
-        Questie:Print("[QuestieTracker] TomTom auto tracking started")
+        Questie:Print("[TomTom] TomTom Auto tracking started")
     end
 
     -- Initialize tracker functions

--- a/Questie.toc
+++ b/Questie.toc
@@ -115,6 +115,7 @@ Modules\QuestieShutUp.lua
 Modules\Sounds.lua
 Modules\TaskQueue.lua
 Modules\QuestiePlayer.lua
+
 #Modules\QuestieDebugOffer.lua
 Modules\WorldMapButton\WorldMapButton.lua
 #Modules\WorldMapButton\QuestieWorldMapButtonTemplate.xml
@@ -191,6 +192,9 @@ Modules\Tracker\TrackerHeaderFrame.lua
 Modules\Tracker\TrackerQuestFrame.lua
 Modules\Tracker\TrackerQuestTimers.lua
 Modules\Tracker\TrackerLinePool.lua
+
+#TomTom
+Modules\TomTom\TomTomAuto.lua
 
 # Tutorial
 Modules\Tutorial\ChooseObjectiveType.lua


### PR DESCRIPTION
- Extract TomTomAuto code into a dedicated module
- Improves code readability
- Reduce risk of calling functions before declaration (previously `GetDistanceToClosestObjective` was called before it was declared in TrackerUtils)
- Expose `TrackerUtils:GetDistanceToClosestObjective` instead of accessing the local function directly

I was driven to do this because of the following error due to your recent changes @trav346 
```lua
...face\AddOns\Questie\Modules\Tracker\TrackerUtils.lua:100: attempt to call global '_GetDistanceToClosestObjective' (a nil value)
``` 