### PR TITLE
Feature update reminder: general cleanup

### DIFF
--- a/Modules/Options/AdvancedTab/QuestieOptionsAdvanced.lua
+++ b/Modules/Options/AdvancedTab/QuestieOptionsAdvanced.lua
@@ -48,6 +48,21 @@ function QuestieOptions.tabs.advanced:Initialize()
                 order = 1,
                 name = function() return l10n('Advanced Settings'); end,
             },
+            updateReminderToggle = {
+                type = "toggle",
+                order = 1.05,
+                name = function() return l10n('Disable Update Reminder'); end,
+                desc = function() return l10n('Suppress the login update popup and peer version popups.'); end,
+                width = 1.7,
+                get = function()
+                    return Questie.db and Questie.db.profile and (Questie.db.profile.disableUpdateReminder == true) or false
+                end,
+                set = function(_, value)
+                    if Questie and Questie.db and Questie.db.profile then
+                        Questie.db.profile.disableUpdateReminder = (value == true)
+                    end
+                end,
+            },
             enableIconLimit = {
                 type = "toggle",
                 order = 1.1,

--- a/Modules/Options/QuestieOptionsDefaults.lua
+++ b/Modules/Options/QuestieOptionsDefaults.lua
@@ -154,6 +154,9 @@ function QuestieOptionsDefaults:Load()
             objectiveProgressSoundChoiceName = "ObjectiveProgress",
             iconTheme = "questie",
 
+            -- Update reminder
+            disableUpdateReminder = false,
+
             minimap = {
                 hide = false
             },

--- a/Modules/QuestieSlash.lua
+++ b/Modules/QuestieSlash.lua
@@ -36,8 +36,10 @@ function QuestieSlash.HandleCommands(input)
         table.insert(commands, c)
     end
 
+    -- Parse primary/secondary command early for all handlers
     local mainCommand = commands[1]
     local subCommand = commands[2]
+
 
     -- /questie
     if mainCommand == "" or not mainCommand then
@@ -65,8 +67,6 @@ function QuestieSlash.HandleCommands(input)
         print(Questie:Colorize("/questie dumplog - " .. l10n("Export your quest log data for troubleshooting"), "yellow"));
         print(Questie:Colorize("/questie flex - " .. l10n("Flex the amount of quests you have completed so far"), "yellow"));
         print(Questie:Colorize("/questie doable [questID] - " .. l10n("Prints whether you are eligibile to do a quest"), "yellow"));
-        print(Questie:Colorize("/questie version - " .. l10n("Prints Questie and client version info"), "yellow"));
-        print(Questie:Colorize("/questie version check - " .. l10n("Compare EpogQuestie versions with all server users"), "yellow"));
         return;
     end
 

--- a/Modules/QuestieVersionShare.lua
+++ b/Modules/QuestieVersionShare.lua
@@ -1,9 +1,0 @@
----@class QuestieVersionShare
-local QuestieVersionShare = QuestieLoader:CreateModule("QuestieVersionShare")
-
--- Simple version info module for EpogQuestie
--- Provides easy access to version info and update links
-
-function QuestieVersionShare:Initialize()
-    -- Module initialized silently - version info handled by QuestieInit
-end

--- a/Modules/Reminder/Reminder.lua
+++ b/Modules/Reminder/Reminder.lua
@@ -1,0 +1,85 @@
+---@class QuestieUpdateReminder
+local QuestieUpdateReminder = QuestieLoader:CreateModule("QuestieUpdateReminder")
+
+---@type l10n
+local l10n = QuestieLoader:ImportModule("l10n")
+
+local C_Timer = (QuestieCompat and QuestieCompat.C_Timer) or C_Timer
+
+local shownThisSession = false
+
+-- Internal: defines the popup dialogs once
+local function DefinePopups()
+    if StaticPopupDialogs["QUESTIE_UPDATE_AVAILABLE"] then return end
+
+    StaticPopupDialogs["QUESTIE_UPDATE_AVAILABLE"] = {
+        text = "|cFFFFFF00Questie Epoch|r\nA new version is available.\n\nYour: %s\nLatest: %s\n\nCopy the download link?",
+        button1 = l10n and l10n("Copy Link") or "Copy Link",
+        button2 = l10n and l10n("Later") or "Later",
+        hasEditBox = false,
+        hideOnEscape = true,
+        whileDead = true,
+        timeout = 0,
+        preferredIndex = 3,
+        OnAccept = function(self, data)
+            local url = data and data.url or ""
+            StaticPopup_Show("QUESTIE_UPDATE_COPY_URL", nil, nil, { url = url })
+        end,
+    }
+
+    StaticPopupDialogs["QUESTIE_UPDATE_COPY_URL"] = {
+        text = "Questie Epoch Update URL:",
+        button1 = l10n and l10n("Close") or "Close",
+        hasEditBox = true,
+        editBoxWidth = 280,
+        hideOnEscape = true,
+        whileDead = true,
+        timeout = 0,
+        preferredIndex = 3,
+        OnShow = function(self, data)
+            local url = data and data.url or ""
+            local editBox = self.editBox
+            editBox:SetText(url)
+            editBox:HighlightText()
+            editBox:SetFocus()
+        end,
+        EditBoxOnEscapePressed = function(self)
+            self:GetParent():Hide()
+        end,
+    }
+end
+
+function QuestieUpdateReminder:Initialize()
+    -- No-op: popups are defined on first use; kept for consistency
+end
+
+-- Show a silent popup reminding users to update
+---@param current string
+---@param latest string
+---@param url string
+function QuestieUpdateReminder:ShowPopup(current, latest, url)
+    if Questie and Questie.db and Questie.db.profile and Questie.db.profile.disableUpdateReminder then
+        return
+    end
+    if shownThisSession then return end
+
+    DefinePopups()
+
+    -- Delay slightly after login to avoid combat lockdowns or UI noise
+    local function show()
+        if shownThisSession then return end
+        if Questie and Questie.db and Questie.db.profile and Questie.db.profile.disableUpdateReminder then
+            return
+        end
+        shownThisSession = true
+        StaticPopup_Show("QUESTIE_UPDATE_AVAILABLE", current or "?", latest or "?", { url = url or "" })
+    end
+
+    if C_Timer and C_Timer.After then
+        C_Timer.After(2, show)
+    else
+        show()
+    end
+end
+
+return QuestieUpdateReminder

--- a/Questie.toc
+++ b/Questie.toc
@@ -101,6 +101,7 @@ Modules\Libs\RamerDouglasPeucker.lua
 
 # Modules
 Modules\QuestieValidateGameCache.lua
+Modules\Reminder\Reminder.lua
 Modules\QuestieVersionCheck.lua
 Modules\QuestieInit.lua
 Modules\Fixes\QuestRewardTooltipFix.lua


### PR DESCRIPTION
 Module: Modules/Reminder/Reminder.lua
    - New QuestieUpdateReminder with two popups (update + copy URL), delayed 2s, once per session, respects disableUpdateReminder.
    
<img width="803" height="175" alt="image" src="https://github.com/user-attachments/assets/4529b91a-c25c-4311-a034-bb0ae77a8ff0" />

<img width="408" height="176" alt="Screenshot 2025-09-03 043133" src="https://github.com/user-attachments/assets/f60fbd6b-f902-4857-a2a7-694180c9fed1" />


- Integration: Modules/QuestieVersionCheck.lua
    - Routes “outdated” and “peer newer” to the reminder popup; minimal chat fallback.
    - Registers comms and broadcasts version once (kept as-is); guarded RegisterAddonMessagePrefix for 3.3.5.
    - Uses GITHUB_RELEASES_URL and LATEST_KNOWN_VERSION as the single source of truth.
- Options: Modules/Options/AdvancedTab/QuestieOptionsAdvanced.lua
    - Added “Disable Update Reminder” toggle
    -  Defaults in Modules/Options/QuestieOptionsDefaults.lua (disableUpdateReminder = false).
   Cleanup:
    - Removed dev/test slash and reminder commands from Modules/QuestieSlash.lua; scrubbed help text.
    - Removed /questieversion and /qversion from Modules/QuestieVersionCheck.lua.