### PR TITLE
Fix data collector not initializing, gray out ID options

### DIFF
--- a/Modules/Options/AdvancedTab/QuestieOptionsAdvanced.lua
+++ b/Modules/Options/AdvancedTab/QuestieOptionsAdvanced.lua
@@ -318,7 +318,7 @@ function QuestieOptions.tabs.advanced:Initialize()
                 order = 5.02,
                 name = function() return l10n('Show Item IDs'); end,
                 desc = function() return l10n('When this is checked, the ID of items will shown in tooltips.'); end,
-                disabled = function() return (not Questie.db.profile.enableTooltips or Questie.db.profile.enableDataCollection); end,
+                disabled = function() return ((not Questie.db.profile.enableTooltips) or Questie.db.profile.enableDataCollection); end,
                 width = "full",
                 get = function() return Questie.db.profile.enableTooltipsItemID; end,
                 set = function (_, value)
@@ -330,7 +330,7 @@ function QuestieOptions.tabs.advanced:Initialize()
                 order = 5.03,
                 name = function() return l10n('Show NPC IDs'); end,
                 desc = function() return l10n('When this is checked, the ID of NPCs will be shown in tooltips.'); end,
-                disabled = function() return (not Questie.db.profile.enableTooltips or Questie.db.profile.enableDataCollection); end,
+                disabled = function() return ((not Questie.db.profile.enableTooltips) or Questie.db.profile.enableDataCollection); end,
                 width = "full",
                 get = function() return Questie.db.profile.enableTooltipsNPCID; end,
                 set = function (_, value)
@@ -342,7 +342,7 @@ function QuestieOptions.tabs.advanced:Initialize()
                 order = 5.04,
                 name = function() return l10n('Show Object IDs'); end,
                 desc = function() return l10n('When this is checked, the ID of objects will be shown in tooltips. These are guesses and only show the first matching ID in the QuestieDB.'); end,
-                disabled = function() return (not Questie.db.profile.enableTooltips or Questie.db.profile.enableDataCollection); end,
+                disabled = function() return ((not Questie.db.profile.enableTooltips) or Questie.db.profile.enableDataCollection); end,
                 width = "full",
                 get = function() return Questie.db.profile.enableTooltipsObjectID; end,
                 set = function (_, value)
@@ -354,7 +354,7 @@ function QuestieOptions.tabs.advanced:Initialize()
                 order = 5.05,
                 name = function() return l10n('Show Quest IDs'); end,
                 desc = function() return l10n('When this is checked, the ID of quests will show in tooltips and the tracker.'); end,
-                disabled = function() return (not Questie.db.profile.enableTooltips or Questie.db.profile.enableDataCollection); end,
+                disabled = function() return ((not Questie.db.profile.enableTooltips) or Questie.db.profile.enableDataCollection); end,
                 width = "full",
                 get = function() return Questie.db.profile.enableTooltipsQuestID; end,
                 set = function (_, value)

--- a/Modules/Options/AdvancedTab/QuestieOptionsAdvanced.lua
+++ b/Modules/Options/AdvancedTab/QuestieOptionsAdvanced.lua
@@ -15,6 +15,8 @@ local QuestieTracker = QuestieLoader:ImportModule("QuestieTracker");
 local IsleOfQuelDanas = QuestieLoader:ImportModule("IsleOfQuelDanas");
 ---@type l10n
 local l10n = QuestieLoader:ImportModule("l10n")
+---@type QuestieDataCollector
+local QuestieDataCollector = QuestieLoader:ImportModule("QuestieDataCollector")
 
 QuestieOptions.tabs.advanced = {...}
 local optionsDefaults = QuestieOptionsDefaults:Load()
@@ -316,7 +318,7 @@ function QuestieOptions.tabs.advanced:Initialize()
                 order = 5.02,
                 name = function() return l10n('Show Item IDs'); end,
                 desc = function() return l10n('When this is checked, the ID of items will shown in tooltips.'); end,
-                disabled = function() return (not Questie.db.profile.enableTooltips); end,
+                disabled = function() return (not Questie.db.profile.enableTooltips or Questie.db.profile.enableDataCollection); end,
                 width = "full",
                 get = function() return Questie.db.profile.enableTooltipsItemID; end,
                 set = function (_, value)
@@ -328,7 +330,7 @@ function QuestieOptions.tabs.advanced:Initialize()
                 order = 5.03,
                 name = function() return l10n('Show NPC IDs'); end,
                 desc = function() return l10n('When this is checked, the ID of NPCs will be shown in tooltips.'); end,
-                disabled = function() return (not Questie.db.profile.enableTooltips); end,
+                disabled = function() return (not Questie.db.profile.enableTooltips or Questie.db.profile.enableDataCollection); end,
                 width = "full",
                 get = function() return Questie.db.profile.enableTooltipsNPCID; end,
                 set = function (_, value)
@@ -340,7 +342,7 @@ function QuestieOptions.tabs.advanced:Initialize()
                 order = 5.04,
                 name = function() return l10n('Show Object IDs'); end,
                 desc = function() return l10n('When this is checked, the ID of objects will be shown in tooltips. These are guesses and only show the first matching ID in the QuestieDB.'); end,
-                disabled = function() return (not Questie.db.profile.enableTooltips); end,
+                disabled = function() return (not Questie.db.profile.enableTooltips or Questie.db.profile.enableDataCollection); end,
                 width = "full",
                 get = function() return Questie.db.profile.enableTooltipsObjectID; end,
                 set = function (_, value)
@@ -352,7 +354,7 @@ function QuestieOptions.tabs.advanced:Initialize()
                 order = 5.05,
                 name = function() return l10n('Show Quest IDs'); end,
                 desc = function() return l10n('When this is checked, the ID of quests will show in tooltips and the tracker.'); end,
-                disabled = function() return (not Questie.db.profile.enableTooltips); end,
+                disabled = function() return (not Questie.db.profile.enableTooltips or Questie.db.profile.enableDataCollection); end,
                 width = "full",
                 get = function() return Questie.db.profile.enableTooltipsQuestID; end,
                 set = function (_, value)
@@ -449,19 +451,19 @@ function QuestieOptions.tabs.advanced:Initialize()
                         -- Initialize the data collector
                         if QuestieDataCollector and QuestieDataCollector.Initialize then
                             QuestieDataCollector:Initialize()
+                            DEFAULT_CHAT_FRAME:AddMessage("|cFFFF0000[Questie] Quest Data Collection ENABLED - Developer mode active|r", 1, 0, 0)
                         end
                         -- Enable tooltip IDs for data collection
                         if QuestieDataCollector and QuestieDataCollector.EnableTooltipIDs then
                             QuestieDataCollector:EnableTooltipIDs()
+                            DEFAULT_CHAT_FRAME:AddMessage("|cFFFFFF00[Questie] Tooltip IDs have been enabled to assist with data collection|r", 1, 1, 0)
                         end
-                        DEFAULT_CHAT_FRAME:AddMessage("|cFFFF0000[Questie] Quest Data Collection ENABLED - Developer mode active|r", 1, 0, 0)
-                        DEFAULT_CHAT_FRAME:AddMessage("|cFFFFFF00[Questie] Tooltip IDs have been enabled to assist with data collection|r", 1, 1, 0)
                     else
                         -- Restore original tooltip settings
                         if QuestieDataCollector and QuestieDataCollector.RestoreTooltipIDs then
                             QuestieDataCollector:RestoreTooltipIDs()
+                            DEFAULT_CHAT_FRAME:AddMessage("|cFF00FF00[Questie] Quest Data Collection disabled|r", 0, 1, 0)
                         end
-                        DEFAULT_CHAT_FRAME:AddMessage("|cFF00FF00[Questie] Quest Data Collection disabled|r", 0, 1, 0)
                     end
                 end,
             },

--- a/Modules/QuestieDataCollector.lua
+++ b/Modules/QuestieDataCollector.lua
@@ -2467,7 +2467,7 @@ function QuestieDataCollector:EnableTooltipIDs()
     if not _originalTooltipSettings then
         _originalTooltipSettings = {
             questId = Questie.db.profile.enableTooltipsQuestID,
-            npcId = Questie.db.profile.enableTooltipsNpcID,
+            npcId = Questie.db.profile.enableTooltipsNPCID,
             objectId = Questie.db.profile.enableTooltipsObjectID,
             itemId = Questie.db.profile.enableTooltipsItemID
         }
@@ -2475,7 +2475,7 @@ function QuestieDataCollector:EnableTooltipIDs()
     
     -- Enable all IDs in tooltips for better data collection
     Questie.db.profile.enableTooltipsQuestID = true
-    Questie.db.profile.enableTooltipsNpcID = true
+    Questie.db.profile.enableTooltipsNPCID = true
     Questie.db.profile.enableTooltipsObjectID = true
     Questie.db.profile.enableTooltipsItemID = true
 end


### PR DESCRIPTION
- Fixed the data collector not actually being initialized and tooltip IDs not being enabled when the data collection option is checked due to the QuestieDataCollector module not being imported.
- Fixed the NPC ID option not being enabled in QuestieDataCollector:EnableTooltipIDs() due to case sensitivity.
- Grayed out all the tooltip ID options when the data collector is enabled since they are intended to be force-enabled.

Related: #102 #871 