### PR TITLE
Fixed restoring settings when disabling qdc

### DIFF
--- a/Modules/Options/AdvancedTab/QuestieOptionsAdvanced.lua
+++ b/Modules/Options/AdvancedTab/QuestieOptionsAdvanced.lua
@@ -460,8 +460,8 @@ function QuestieOptions.tabs.advanced:Initialize()
                         end
                     else
                         -- Restore original tooltip settings
-                        if QuestieDataCollector and QuestieDataCollector.RestoreTooltipIDs then
-                            QuestieDataCollector:RestoreTooltipIDs()
+                        if QuestieDataCollector and QuestieDataCollector.RestoreTooltipSettings then
+                            QuestieDataCollector:RestoreTooltipSettings()
                             DEFAULT_CHAT_FRAME:AddMessage("|cFF00FF00[Questie] Quest Data Collection disabled|r", 0, 1, 0)
                         end
                     end

--- a/Modules/QuestieDataCollector.lua
+++ b/Modules/QuestieDataCollector.lua
@@ -2483,7 +2483,7 @@ end
 function QuestieDataCollector:RestoreTooltipSettings()
     if _originalTooltipSettings then
         Questie.db.profile.enableTooltipsQuestID = _originalTooltipSettings.questId
-        Questie.db.profile.enableTooltipsNpcID = _originalTooltipSettings.npcId
+        Questie.db.profile.enableTooltipsNPCID = _originalTooltipSettings.npcId
         Questie.db.profile.enableTooltipsObjectID = _originalTooltipSettings.objectId
         Questie.db.profile.enableTooltipsItemID = _originalTooltipSettings.itemId
         


### PR DESCRIPTION
Here's a couple more fixes, I noticed it didn't actually restore previous tooltip ID settings when QDC was disabled. It was just calling the wrong function name (RestoreTooltipIDs instead of RestoreTooltipSettings) and had the wrong casing on the NPC ID variable again.