### PR TITLE
Update Installation Instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ NOTE: Data submissions prior to v1.1.1 will soon be deprecated.
 ## 📦 Installation
 
 ### **Automatic Installation (Recommended)**
-1. **Download**: Get the latest release from [GitHub Releases](https://github.com/trav346/Questie/releases)
+1. **Download**: Get the latest release from [GitHub Releases](https://github.com/trav346/Questie-Epoch/releases/)
 2. **Extract**: Unzip the downloaded file
 3. **Install**: Copy the `Questie` folder to your WoW AddOns directory:
    ```


### PR DESCRIPTION
Update Release URL to point to the correct releases page.

The release link in the README got me a few times, figured I'd take a quick sec to fix it.  Could also link them to "[/releases/latest](https://github.com/trav346/Questie-Epoch/releases/latest)" if you want them to only see the latest release. 